### PR TITLE
Remove mention of Chrome Frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Seriously.js requires a browser that supports [WebGL](http://en.wikipedia.org/wi
 Development is targeted to and tested in Firefox (4.0+) and Google Chrome (9+). Safari
 and Opera are [expected to support WebGL](http://caniuse.com/#search=webgl)
 in the near future. There are no public plans for Internet Explorer to
-support WebGL, though it may be available using the Chrome Frame plugin.
+support WebGL.
 
 Even though a browser may support WebGL, the ability to run it depends
 on the system's graphics card. Serioulsy.js is heavily optimized, so most


### PR DESCRIPTION
[Chrome Frame is being retired](http://blog.chromium.org/2013/06/retiring-chrome-frame.html), so I removed the recommendation to use it.
