### PR TITLE
Camera example with edge detection

### DIFF
--- a/examples/camera/index.html
+++ b/examples/camera/index.html
@@ -20,7 +20,7 @@
 		// declare our variables
 		var seriously, // the main object that holds the entire composition
 			gUM, // will reference getUserMedia or whatever browser-prefixed version we can find
-			url, // will reference window.URL or whatever browser-prefixed version we can find
+			URL, // will reference window.URL or whatever browser-prefixed version we can find
 			video, // video element
 			source, // wrapper object for source video
 			edge, // edge detection effect
@@ -30,7 +30,7 @@
 		gUM = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia;
 
 		// detect browser-prefixed window.URL
-		url = window.URL || window.webkitURL || window.mozURL || window.msURL;
+		URL = window.URL || window.webkitURL || window.mozURL || window.msURL;
 
 		// grab the video element
 		video = document.getElementById('source');
@@ -48,13 +48,13 @@
 					if (video.mozCaptureStream) {
 						video.mozSrcObject = stream;
 					} else {
-						video.src = (url && url.createObjectURL( stream )) || stream;
+						video.src = (URL && URL.createObjectURL( stream )) || stream;
 					}
 					video.play();
 				}, 
 				// error callback
 				function(error){
-					console.log("An error occurred: [CODE " + error.code + "]");
+					console.log("An error occurred: " + (error.message || error.name) + "");
 				}
 			);
 		}


### PR DESCRIPTION
Resubmitting pull-request #32 to the `develop` branch with the following modifications:
- No longer rewriting browser globals like `window.URL` and `navigator.getUserMedia`.
- Fixed undeclared `error` in error callback for `getUserMedia`
- Wait for `canplay` video event to start Seriously rendering to avoid render warnings

**Note:** In the `develop` branch the video is no longer rendering to the canvas in FireFox. However, it's also not working in the main example so it seems like there is something in progress elsewhere that is causing this. I dropped the exact same code into the master branch and it works fine in FireFox.
