### PR TITLE
camera options

### DIFF
--- a/sources/seriously.camera.js
+++ b/sources/seriously.camera.js
@@ -68,9 +68,11 @@
 
 			video = document.createElement('video');
 
-			getUserMedia.call(navigator, {
-				video: true
-			}, function (s) {
+			var opts = {video:true};
+			if(typeof source == 'object'){
+				opts = source;
+			}
+			getUserMedia.call(navigator, opts, function (s) {
 				stream = s;
 
 				if (destroyed) {


### PR DESCRIPTION
Camera options can be passed through the source argument. I'm not sure if this is ideal, but I think it would be good not tamper with the userMedia options. Let the user have complete control over them.

```
        var camera = seriously.source('camera', {
            video:{
                mandatory: {
                    minWidth: 1280,
                    minHeight: 800
                }
            }
        });
```
