### PR TITLE
get three canvas context from options argument

### DIFF
--- a/targets/seriously.three.js
+++ b/targets/seriously.three.js
@@ -61,7 +61,7 @@
 					gl = options.gl;
 				} else if (options.canvas) {
 					try {
-						gl = canvas.getContext('webgl');
+						gl = options.canvas.getContext('webgl');
 					} catch (expError) {
 					}
 


### PR DESCRIPTION
In the example, canvas was a global object defined in the main script so it would always get the context from it, and not from the arguments.