### PR TITLE
Fix divide-by-zero bug in chroma effect at some Android devices

### DIFF
--- a/effects/seriously.chroma.js
+++ b/effects/seriously.chroma.js
@@ -101,7 +101,7 @@
 				*/
 				'	float alpha = max(0.0, 1.0 - pixelSat / screenSat);',
 				'	alpha = smoothstep(clipBlack, clipWhite, alpha);',
-				'	vec4 semiTransparentPixel = vec4((sourcePixel.rgb - (1.0 - alpha) * screen.rgb * screenWeight) / max(0.00001, alpha), alpha);',
+				'	vec4 semiTransparentPixel = vec4((sourcePixel.rgb - (1.0 - alpha) * screen.rgb * screenWeight) / max(0.0001, alpha), alpha);',
 
 				'	vec4 pixel = mix(semiTransparentPixel, sourcePixel, solid);',
 


### PR DESCRIPTION
Related #80 