### PR TITLE
Adds precision argument to chroma effect

### DIFF
--- a/effects/seriously.chroma.js
+++ b/effects/seriously.chroma.js
@@ -74,6 +74,7 @@
 				'uniform float clipBlack;',
 				'uniform float clipWhite;',
 				'uniform bool mask;',
+				'uniform float clipPrecision;',
 
 				'varying float screenSat;',
 				'varying vec3 screenPrimary;',
@@ -101,7 +102,7 @@
 				*/
 				'	float alpha = max(0.0, 1.0 - pixelSat / screenSat);',
 				'	alpha = smoothstep(clipBlack, clipWhite, alpha);',
-				'	vec4 semiTransparentPixel = vec4((sourcePixel.rgb - (1.0 - alpha) * screen.rgb * screenWeight) / max(0.00001, alpha), alpha);',
+				'	vec4 semiTransparentPixel = vec4((sourcePixel.rgb - (1.0 - alpha) * screen.rgb * screenWeight) / max(clipPrecision, alpha), alpha);',
 
 				'	vec4 pixel = mix(semiTransparentPixel, sourcePixel, solid);',
 
@@ -170,6 +171,13 @@
 				defaultValue: false,
 				uniform: 'mask',
 				shaderDirty: true
+			},
+			precision: {
+				type: 'float',
+				uniform: 'clipPrecision',
+				defaultValue: 0.00001,
+				min: 0.00001,
+				max: 1.0
 			}
 		},
 		title: 'Chroma Key',


### PR DESCRIPTION
As mentioned in issue #80 some devices will add black areas when using chroma due to problems when rounding the alpha value. This pull request adds a precision argument to the chroma effect to easily change the rounding factor to fit specific devices.

The default value is the original 0.00001 so this shouldn't break anything for existing scripts.
For example: on the iPad 2 with Safari 9, iOS 9.3 I had to change the precision to 0.01 for the chroma effect to work reliably.

    chroma = seriously.effect('chroma');
    chroma.precision = 0.01;