### PR TITLE
use video.srcObject

### DIFF
--- a/examples/camera/index.html
+++ b/examples/camera/index.html
@@ -42,12 +42,7 @@
 				{video: true},
 				// success callback
 				function(stream){
-					// check for firefox
-					if (video.mozCaptureStream) {
-						video.mozSrcObject = stream;
-					} else {
-						video.src = (URL && URL.createObjectURL(stream)) || stream;
-					}
+					video.srcObject = stream;
 					video.play();
 				},
 				// error callback

--- a/index.html
+++ b/index.html
@@ -296,11 +296,7 @@
 						target.width = video.videoWidth;
 					}
 
-					if (window.webkitURL) {
-						video.src = window.webkitURL.createObjectURL(stream);
-					} else {
-						video.src = stream;
-					}
+					video.srcObject = stream;
 
 					webCamStream = stream;
 

--- a/sources/seriously.camera.js
+++ b/sources/seriously.camera.js
@@ -93,12 +93,7 @@
 					return;
 				}
 
-				// check for firefox
-				if (video.mozCaptureStream) {
-					video.mozSrcObject = stream;
-				} else {
-					video.src = (URL && URL.createObjectURL(stream)) || stream;
-				}
+				video.srcObject = stream;
 
 				if (video.readyState) {
 					initialize();


### PR DESCRIPTION
A tiny refresh of the camera support to use ``.srcObject = stream`` instead of ``URL.createObjectURL``.