### PR TITLE
Use srcObject (createObjectURL is soon deprecated)

### DIFF
--- a/examples/camera/index.html
+++ b/examples/camera/index.html
@@ -46,7 +46,11 @@
 					if (video.mozCaptureStream) {
 						video.mozSrcObject = stream;
 					} else {
-						video.src = (URL && URL.createObjectURL(stream)) || stream;
+						if (typeof video.srcObject === "object") {
+							video.srcObject = stream;
+						} else {
+							video.src = (URL && URL.createObjectURL(stream)) || stream;
+						}
 					}
 					video.play();
 				},

--- a/index.html
+++ b/index.html
@@ -296,7 +296,9 @@
 						target.width = video.videoWidth;
 					}
 
-					if (window.webkitURL) {
+					if (typeof video.srcObject === "object") {
+						video.srcObject = stream;
+					} else if (window.webkitURL) {
 						video.src = window.webkitURL.createObjectURL(stream);
 					} else {
 						video.src = stream;

--- a/sources/seriously.camera.js
+++ b/sources/seriously.camera.js
@@ -94,7 +94,9 @@
 				}
 
 				// check for firefox
-				if (video.mozCaptureStream) {
+				if (typeof video.srcObject === "object") {
+					video.srcObject = stream;
+				} else if (video.mozCaptureStream) {
 					video.mozSrcObject = stream;
 				} else {
 					video.src = (URL && URL.createObjectURL(stream)) || stream;


### PR DESCRIPTION
Fixes Seriously to work on Chrome Beta as the beta branch has already
deprecated createObjectURL for MediaStreams.
Additional info: https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL